### PR TITLE
Fix GHC 7.0.1 build by workind around Trac #4498

### DIFF
--- a/src/Data/ByteString/Builder/Internal.hs
+++ b/src/Data/ByteString/Builder/Internal.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE ScopedTypeVariables, CPP, BangPatterns, RankNTypes #-}
+#if __GLASGOW_HASKELL__ == 700
+-- This is needed as a workaround for an old bug in GHC 7.0.1 (Trac #4498)
+{-# LANGUAGE MonoPatBinds #-}
+#endif
 #if __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Unsafe #-}
 #endif
@@ -92,7 +96,7 @@ module Data.ByteString.Builder.Internal (
   , lazyByteStringCopy
   , lazyByteStringInsert
   , lazyByteStringThreshold
-  
+
   , shortByteString
 
   , maximalCopySize

--- a/src/Data/ByteString/Builder/Prim.hs
+++ b/src/Data/ByteString/Builder/Prim.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE CPP, BangPatterns, ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
+#if __GLASGOW_HASKELL__ == 700
+-- This is needed as a workaround for an old bug in GHC 7.0.1 (Trac #4498)
+{-# LANGUAGE MonoPatBinds #-}
+#endif
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
 #endif


### PR DESCRIPTION
`bytestring-builder` currently fails to build on GHC 7.0.1 due to a very old GHC bug, [Trac #4498](https://ghc.haskell.org/trac/ghc/ticket/4498). Luckily, it's extremely easy to work around this issue by just using the old `MonoPatBinds` pragma, as Simon recommends [here](https://ghc.haskell.org/trac/ghc/ticket/4498#comment:2).

This mirrors the changes in https://github.com/haskell/bytestring/pull/91.

Fixes #9.
